### PR TITLE
Enabling login callback proxying

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -190,6 +190,16 @@ class AppSettings(object):
         return self._setting('LOGIN_ON_EMAIL_CONFIRMATION', True)
 
     @property
+    def LOGIN_CALLBACK_PROXY(self):
+        return self._setting('LOGIN_CALLBACK_PROXY', '')
+
+    @property
+    def LOGIN_PROXY_REDIRECT_WHITELIST(self):
+        unsanitized_list = (
+            self._setting('LOGIN_PROXY_REDIRECT_WHITELIST', '').split(','))
+        return [x.strip() for x in unsanitized_list if len(x.strip()) > 0]
+
+    @property
     def LOGOUT_REDIRECT_URL(self):
         return self._setting('LOGOUT_REDIRECT_URL', '/')
 

--- a/allauth/socialaccount/providers/fake/models.py
+++ b/allauth/socialaccount/providers/fake/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/fake/provider.py
+++ b/allauth/socialaccount/providers/fake/provider.py
@@ -1,0 +1,62 @@
+from allauth.account.models import EmailAddress
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import (ProviderAccount,
+                                                  AuthAction)
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.socialaccount.app_settings import QUERY_EMAIL
+
+
+class Scope(object):
+    EMAIL = 'email'
+    PROFILE = 'profile'
+
+
+class FakeAccount(ProviderAccount):
+    def get_profile_url(self):
+        return self.account.extra_data.get('link')
+
+    def get_avatar_url(self):
+        return self.account.extra_data.get('picture')
+
+    def to_str(self):
+        dflt = super(FakeAccount, self).to_str()
+        return self.account.extra_data.get('name', dflt)
+
+
+class FakeProvider(OAuth2Provider):
+    id = 'fake'
+    name = 'Fake'
+    package = 'allauth.socialaccount.providers.fake'
+    account_class = FakeAccount
+
+    def get_default_scope(self):
+        scope = [Scope.PROFILE]
+        if QUERY_EMAIL:
+            scope.append(Scope.EMAIL)
+        return scope
+
+    def get_auth_params(self, request, action):
+        ret = super(FakeProvider, self).get_auth_params(request,
+                                                        action)
+        if action == AuthAction.REAUTHENTICATE:
+            ret['approval_prompt'] = 'force'
+        return ret
+
+    def extract_uid(self, data):
+        return str(data['id'])
+
+    def extract_common_fields(self, data):
+        return dict(email=data.get('email'),
+                    last_name=data.get('family_name'),
+                    first_name=data.get('given_name'))
+
+    def extract_email_addresses(self, data):
+        ret = []
+        email = data.get('email')
+        if email and data.get('verified_email'):
+            ret.append(EmailAddress(
+                email=email, verified=True, primary=True))
+        return ret
+
+
+providers.registry.register(FakeProvider)

--- a/allauth/socialaccount/providers/fake/urls.py
+++ b/allauth/socialaccount/providers/fake/urls.py
@@ -1,0 +1,4 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+from .provider import FakeProvider
+
+urlpatterns = default_urlpatterns(FakeProvider)

--- a/allauth/socialaccount/providers/fake/views.py
+++ b/allauth/socialaccount/providers/fake/views.py
@@ -1,0 +1,26 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
+                                                          OAuth2LoginView,
+                                                          OAuth2CallbackView)
+
+from .provider import FakeProvider
+
+
+class FakeOAuth2Adapter(OAuth2Adapter):
+    provider_id = FakeProvider.id
+    access_token_url = 'https://localhost/o/oauth2/token'
+    authorize_url = 'https://localhost/o/oauth2/auth'
+    profile_url = 'https://localhost/oauth2/v1/userinfo'
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = requests.get(self.profile_url,
+                            params={'access_token': token.token,
+                                    'alt': 'json'})
+        extra_data = resp.json()
+        return self.get_provider().sociallogin_from_response(
+            request, extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(FakeOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(FakeOAuth2Adapter)

--- a/allauth/socialaccount/providers/oauth2/tests.py
+++ b/allauth/socialaccount/providers/oauth2/tests.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json, re, sys
+
+from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.exceptions import PermissionDenied
+from django.core.urlresolvers import reverse, NoReverseMatch, clear_url_caches, set_urlconf
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from django.utils.http import urlquote_plus as urlquote, urlunquote_plus as urlunquote
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
+from allauth.account import app_settings as account_settings
+from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.providers import registry
+from allauth.socialaccount.providers.fake.views import FakeOAuth2Adapter
+from allauth.socialaccount.tests import create_oauth2_tests
+from allauth.tests import MockedResponse
+from allauth.utils import get_current_site
+
+from requests.exceptions import HTTPError
+
+from .views import OAuth2Adapter, OAuth2LoginView, proxy_login_callback, MissingParameter
+
+
+class OAuth2Tests(TestCase):
+    def param(self, param, url):
+        # Look for a redirect uri
+        url = urlunquote(url)
+        m = re.match('.*%s=(.*?)[|&.*]' % param, url)
+        if m is None:
+            return ''
+        return m.group(1)
+
+    def init_request(self, endpoint, params):
+        self.request = RequestFactory().get(reverse(endpoint), params)
+        SessionMiddleware().process_request(self.request)
+
+    def setUp(self):
+        app = SocialApp.objects.create(provider=FakeOAuth2Adapter.provider_id,
+                                       name=FakeOAuth2Adapter.provider_id,
+                                       client_id='app123id',
+                                       key=FakeOAuth2Adapter.provider_id,
+                                       secret='dummy')
+        app.sites.add(get_current_site())
+
+
+class OAuth2TestsNoProxying(OAuth2Tests):
+    def setUp(self):
+        self.init_request('fake_login', dict(process='login'))
+        super(OAuth2TestsNoProxying, self).setUp()
+
+    def test_proxyless_login(self):
+        login_view = OAuth2LoginView.adapter_view(FakeOAuth2Adapter)
+        login_response = login_view(self.request)
+        self.assertEqual(login_response.status_code, 302)  # Redirect
+        self.assertEqual(self.param('redirect_uri', login_response['location']),
+                         'http://testserver/fake/login/callback/')
+
+    def test_is_not_login_proxy(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse('fake_proxy')
+
+
+@override_settings(ACCOUNT_LOGIN_CALLBACK_PROXY='https://loginproxy')
+class OAuth2TestsUsesProxy(OAuth2Tests):
+    def setUp(self):
+        self.init_request('fake_login', dict(process='login'))
+        super(OAuth2TestsUsesProxy, self).setUp()
+
+    def test_login_by_proxy(self):
+        login_view = OAuth2LoginView.adapter_view(FakeOAuth2Adapter)
+        login_response = login_view(self.request)
+        self.assertEqual(login_response.status_code, 302)  # Redirect
+        self.assertEqual(self.param('redirect_uri', login_response['location']),
+                         'https://loginproxy/fake/login/callback/proxy/')
+        state = json.loads(self.param('state', login_response['location']))
+        self.assertEqual(state['host'], 'http://testserver/fake/login/')
+
+    def test_is_not_login_proxy(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse('fake_proxy')
+
+
+@override_settings(ACCOUNT_LOGIN_PROXY_REDIRECT_WHITELIST=
+                   'https://cheshirecat,https://tweedledee,')
+class OAuth2TestsIsProxy(OAuth2Tests):
+    def reload_urls(self):
+        for module in sys.modules:
+            if module.endswith('urls'):
+                reload(sys.modules[module])
+        clear_url_caches()
+
+
+    def setUp(self):
+        super(OAuth2TestsIsProxy, self).setUp()
+        self.reload_urls()
+
+    @override_settings(ACCOUNT_LOGIN_PROXY_REDIRECT_WHITELIST='')
+    def tearDown(self):
+        super(OAuth2TestsIsProxy, self).tearDown()
+        self.reload_urls()
+
+    def tests_is_login_proxy(self):
+        reverse('fake_proxy')
+
+    def test_rejects_request_with_no_host_in_state(self):
+        self.init_request('fake_proxy', dict(process='login'))
+        with self.assertRaises(MissingParameter):
+            proxy_login_callback(
+                self.request, callback_view_name='fake_callback')
+
+    def test_rejects_request_with_unwhitelisted_host(self):
+        state = {'host': 'https://tweedledum'}
+        self.init_request(
+            'fake_proxy', dict(process='login', state=json.dumps(state)))
+        with self.assertRaises(PermissionDenied):
+            proxy_login_callback(
+                self.request, callback_view_name='fake_callback')
+
+    def tests_redirects_request_with_whitelisted_host(self):
+        state = {'host': 'https://tweedledee'}
+        serialized_state = json.dumps(state)
+        self.init_request(
+            'fake_proxy', dict(process='login', state=serialized_state))
+        proxy_response = proxy_login_callback(
+            self.request, callback_view_name='fake_callback')
+        self.assertEqual(proxy_response.status_code, 302)  # Redirect
+        self.assertEqual(
+            proxy_response['location'],
+            ('https://tweedledee/fake/login/callback/'
+            '?process=login&state=%s' % urlquote(serialized_state)))
+
+    def test_rejects_request_with_scheme_mismatch(self):
+        state = {'host': 'ftp://tweedledee'}
+        self.init_request(
+            'fake_proxy', dict(process='login', state=json.dumps(state)))
+        with self.assertRaises(PermissionDenied):
+            proxy_login_callback(
+                self.request, callback_view_name='fake_callback')
+
+    def test_rejects_request_with_whitelisted_prefix(self):
+        state = {'host': 'https://tweedledee.creds4u.biz'}
+        self.init_request(
+            'fake_proxy', dict(process='login', state=json.dumps(state)))
+        with self.assertRaises(PermissionDenied):
+            proxy_login_callback(
+                self.request, callback_view_name='fake_callback')

--- a/allauth/socialaccount/providers/oauth2/urls.py
+++ b/allauth/socialaccount/providers/oauth2/urls.py
@@ -1,11 +1,20 @@
 from django.conf.urls import patterns, url, include
 
+from allauth.account import app_settings
+from allauth.socialaccount.providers.oauth2.views import proxy_login_callback
 
 def default_urlpatterns(provider):
     urlpatterns = patterns(provider.package + '.views',
                            url('^login/$', 'oauth2_login',
                                name=provider.id + "_login"),
                            url('^login/callback/$', 'oauth2_callback',
-                               name=provider.id + "_callback"))
+                               name=provider.id + '_callback'))
 
+    if app_settings.LOGIN_PROXY_REDIRECT_WHITELIST:
+        urlpatterns += patterns('',
+            url('^login/callback/proxy/$',
+                proxy_login_callback,
+                {'callback_view_name': provider.id + '_callback'},
+                name=provider.id + '_proxy')
+        )
     return patterns('', url('^' + provider.id + '/', include(urlpatterns)))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -104,6 +104,26 @@ ACCOUNT_USERNAME_REQUIRED (=True)
   `ACCOUNT_AUTHENTICATION_METHOD` is set to `email`. Set to `False`
   when you do not wish to prompt the user to enter a username.
 
+ACCOUNT_LOGIN_CALLBACK_PROXY (="")
+  Redirect the login callback to this remote server or endpoint, instead of the
+  default endpoint on the local server. The remote server could be any server.
+  However, it is suggested that the remote server be an instance of the local
+  server, at a dedicated URL. By enabling
+  ACCOUNT_LOGIN_PROXY_REDIRECT_WHITELIST on the remote server, it will function
+  as a reverse proxy. It will forward the callback request to the local server.
+
+  This is useful for working around an OAuth2 redirect_uri whitelist.
+
+  Specifically, this is useful for authenticating arbitrarily-named and
+  short-lived feature deploys on Google's OAuth2 endpoint. Rather than
+  adding each name to the redirect_uri whitelist, one can permanently
+  redirect to the LOGIN_CALLBACK_PROXY instead, which forwards the OAuth2 code
+  to the feature-deploy.
+
+ACCOUNT_LOGIN_PROXY_REDIRECT_WHITELIST (="")
+  List of remote servers to which this server may forward OAuth2 token proxy
+  redirects (see above).
+
 ACCOUNT_PASSWORD_INPUT_RENDER_VALUE (=False)
   `render_value` parameter as passed to `PasswordInput` fields.
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -46,7 +46,7 @@ else:
         "django.core.context_processors.static",
         "django.core.context_processors.request",
         "django.contrib.messages.context_processors.messages",
-    
+
         "allauth.account.context_processors.account",
         "allauth.socialaccount.context_processors.socialaccount",
     )
@@ -83,6 +83,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.evernote',
     'allauth.socialaccount.providers.feedly',
     'allauth.socialaccount.providers.facebook',
+    'allauth.socialaccount.providers.fake',
     'allauth.socialaccount.providers.flickr',
     'allauth.socialaccount.providers.foursquare',
     'allauth.socialaccount.providers.google',


### PR DESCRIPTION
This PR is #1 of 3 in enabling OAuth2 for backend feature deploys, and may be reviewed in full immediately.

Enable "login proxying", that is.
(1) Enable OAuth2 clients to redirect the OAuth2 provider response (i.e. OAuth2 code) to a separate proxy server. This works around the OAuth2 provider's redirect_uri whitelist.
(2) Enable OAuth2 clients to function as such a proxy. Specifically, add an endpoint to receive OAuth2 provider responses, and redirect them back to the original requesting client. This proxy should be an identical deployment as the original requesting client, just in a permanent location.

Both of these features are optionally toggled by the django  "settings" module, which clients will presumably attach to environment variables. Without these settings explicitly enabled, these features are completely disabled.

To support this redirection, request parameters are now transmitted in the "state" variable instead of being stored in the session cookie. This is crucial because the original requesting client must store its own location in the "state" variable. django/allauth historically supported this, then removed it as part of implementing XSRF protection. This removal was probably incidental.
