### PR TITLE
feature/android_cci

### DIFF
--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -204,3 +204,15 @@ class GoogleTests(create_oauth2_tests(registry.by_id(GoogleProvider.id))):
         self.assertEqual(len(mail.outbox), 1)
         self.login(self.get_mocked_response(verified_email=False))
         self.assertEqual(len(mail.outbox), 1)
+
+    def test_callback_android(self):
+        from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
+        from allauth.socialaccount.providers.google.views import GoogleOAuth2AndroidCallbackView
+
+        androidCallback = GoogleOAuth2AndroidCallbackView()
+        androidCallback.adapter = GoogleOAuth2Adapter()
+        androidCallback.request = RequestFactory().get(reverse(self.provider.id + '_callback_android'))
+        app = androidCallback.adapter.get_provider().get_app(androidCallback.request)
+
+        client = androidCallback.get_client(androidCallback.request, app)
+        self.assertEqual("", client.callback_url)

--- a/allauth/socialaccount/providers/google/urls.py
+++ b/allauth/socialaccount/providers/google/urls.py
@@ -1,4 +1,8 @@
+from django.conf.urls import patterns, url
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 from .provider import GoogleProvider
+from .views import oauth2_callback_android
 
 urlpatterns = default_urlpatterns(GoogleProvider)
+urlpatterns += patterns('', url('^' + GoogleProvider.id + '/login/callback_android/$', oauth2_callback_android,
+                               name=GoogleProvider.id + '_callback_android'))

--- a/allauth/socialaccount/providers/google/views.py
+++ b/allauth/socialaccount/providers/google/views.py
@@ -24,6 +24,13 @@ class GoogleOAuth2Adapter(OAuth2Adapter):
                                        extra_data)
         return login
 
+class GoogleOAuth2AndroidCallbackView(OAuth2CallbackView):
+    def get_client(self, request, app):
+        client = super(GoogleOAuth2AndroidCallbackView, self).get_client(request, app)
+        client.callback_url = ""
+        return client
+
 
 oauth2_login = OAuth2LoginView.adapter_view(GoogleOAuth2Adapter)
 oauth2_callback = OAuth2CallbackView.adapter_view(GoogleOAuth2Adapter)
+oauth2_callback_android = GoogleOAuth2AndroidCallbackView.adapter_view(GoogleOAuth2Adapter)


### PR DESCRIPTION
PREFACE:
Android supports a special OAuth flow for Google accounts that are already logged in on the device. In such a situation, developers can ask the Android system to perform an OAuth flow instead of going through a web based flow. The user simply grants permissions and they're done. This flow is referred to as [Cross Client Identity](https://developers.google.com/identity/protocols/CrossClientAuth) Once permissions have been granted, much like a web based OAuth flow, Google provides a one time use authorization code. The server [exchanges the code](https://developers.google.com/identity/protocols/OAuth2WebServer#handlingtheresponse), along with several other values for an access token and a refresh token that can be used to perform actions on the users behalf.

One of the values passed during the access code exchange is referred to as the redirect_uri. While this parameter serves an actual purpose during a normal web based OAuth 2 flow, it actually serves no purpose in the code exchange. Nonetheless, the redirect_uri must normally be one of a few specific values set up in the Google Developer Console. If the authorization code comes from Android however, the redirect_uri value must instead be either the empty string or "urn:ietf:wg:oauth:2.0:oob". AllAuth cannot be configured to pass either of those values.

This PR aims to solve this issue by adding an extra endpoint to the Google provider for Android clients to use when passing the authorization code to the back end. The new endpoint subclasses from the standard OAuth2CallbackView that powers a normal OAuth 2 callback. The altered redirect_uri value is achieved by altering the returned value of the get_client function such that the callback_url value is set to the empty string.
