### PR TITLE
Fix py3 incompatible proxy changes

### DIFF
--- a/allauth/socialaccount/providers/oauth2/tests.py
+++ b/allauth/socialaccount/providers/oauth2/tests.py
@@ -6,8 +6,9 @@ import json, re, sys
 
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.contrib.sites.models import Site
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse, NoReverseMatch, clear_url_caches, set_urlconf
+from django.urls import reverse, NoReverseMatch, clear_url_caches, set_urlconf
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -25,11 +26,24 @@ from allauth.socialaccount.providers import registry
 from allauth.socialaccount.providers.fake.views import FakeOAuth2Adapter
 from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.tests import MockedResponse
-from allauth.utils import get_current_site
 
 from requests.exceptions import HTTPError
 
 from .views import OAuth2Adapter, OAuth2LoginView, proxy_login_callback, MissingParameter
+
+def get_current_site(request=None):
+    """Wrapper around ``Site.objects.get_current`` to handle ``Site`` lookups
+    by request in Django >= 1.8.
+    :param request: optional request object
+    :type request: :class:`django.http.HttpRequest`
+    """
+    # >= django 1.8
+    if request and hasattr(Site.objects, '_get_site_by_request'):
+        site = Site.objects.get_current(request=request)
+    else:
+        site = Site.objects.get_current()
+
+    return site
 
 
 class OAuth2Tests(TestCase):

--- a/allauth/socialaccount/providers/oauth2/tests.py
+++ b/allauth/socialaccount/providers/oauth2/tests.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.http import urlquote_plus as urlquote, urlunquote_plus as urlunquote
+from django.utils import six
 
 try:
     from importlib import import_module
@@ -116,7 +117,7 @@ class OAuth2TestsIsProxy(OAuth2Tests):
     def reload_urls(self):
         for module in sys.modules:
             if module.endswith('urls'):
-                reload(sys.modules[module])
+                six.moves.reload_module(sys.modules[module])
         clear_url_caches()
 
 

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 
-from urlparse import urljoin
-from urlparse import urlparse
+from allauth.compat import urlparse, urljoin
 
 from requests import RequestException
 


### PR DESCRIPTION
We made the assumption that this repo supports py3 - but it looks like the changes we made to it 5yrs ago were not py3 compatible and when we rebased, this was not tested :(

As a result oauth was failing on py3 feature stacks - this should fix that

The issue was the import of `urlparse` and `urljoin`. This PR imports those modules from `allauth.compat` which provides a handy alias for those imports in this repo.

Before (we were hitting the ImportError because the provider was erroring out at the imports):
```
[ins] In [6]: for provider in providers.registry.get_list(): 
         ...:     try: 
         ...:         prov_mod = import_module(provider.get_package() + '.urls') 
         ...:     except ImportError: 
         ...:         continue  
         ...:     prov_urlpatterns = getattr(prov_mod, 'urlpatterns', None) 
         ...:     if prov_urlpatterns: 
         ...:         urlpatterns += prov_urlpatterns 
         ...:                                                                                                                                                                            

[ins] In [7]: urlpatterns                                                                                                                                                                
Out[7]: [<RegexURLResolver <module 'allauth.urls' from '/Users/savinay/.pyenv/versions/3.6.6/envs/vbe36/src/django-allauth/allauth/urls.py'> (None:None) ^accounts/>]
```

After:
```
[ins] In [12]: for provider in providers.registry.get_list(): 
          ...:     try: 
          ...:         prov_mod = import_module(provider.get_package() + '.urls') 
          ...:     except ImportError: 
          ...:         continue 
          ...:     prov_urlpatterns = getattr(prov_mod, 'urlpatterns', None) 
          ...:     if prov_urlpatterns: 
          ...:         urlpatterns += prov_urlpatterns 
          ...:                                                                                                                                                                           

[ins] In [13]: urlpatterns                                                                                                                                                               
Out[13]: 
[<RegexURLResolver <module 'allauth.urls' from '/Users/savinay/.pyenv/versions/3.6.6/envs/vbe36/src/django-allauth/allauth/urls.py'> (None:None) ^accounts/>,
 <RegexURLResolver <RegexURLPattern list> (None:None) ^google/>,
 <RegexURLPattern google_callback_android ^google/login/callback_android/$>,
 <RegexURLResolver <RegexURLPattern list> (None:None) ^microsoft/>]
```


kinda related: Tests we wrote for this repo broke on the last time this was rebased. 

I took a stab at fixing them - the tests are fragile+flaky and are based on an older version of Django. I got them to a point where they run, but haven't been able to fix them yet.
So the tests are failing but at least we know they are failing and we can run them now...